### PR TITLE
Add KPI preprocessing script with Spark pipeline

### DIFF
--- a/kpi_preprocess.py
+++ b/kpi_preprocess.py
@@ -1,0 +1,122 @@
+from pyspark.sql import SparkSession
+from pyspark.ml import Pipeline
+from pyspark.ml.feature import VectorAssembler, StandardScaler, Imputer, StringIndexer
+import sys
+
+# ---------------------------------------------------------
+# 1. INITIALIZE SPARK SESSION
+# ---------------------------------------------------------
+spark = SparkSession.builder \
+    .appName("KPI_Preprocessing_Job") \
+    .getOrCreate()
+
+spark.sparkContext.setLogLevel("WARN")
+print(">>> [INIT] Spark Session Created Successfully")
+
+# ---------------------------------------------------------
+# 2. DEFINE HDFS PATHS
+# ---------------------------------------------------------
+# UPDATED: Using port 8020 for both Input and Output
+input_path = "hdfs://namenode:8020/data/raw/40_kpi_output.csv"
+output_path = "hdfs://namenode:8020/data/processed/kpi_features"
+
+# ---------------------------------------------------------
+# 3. LOAD DATA
+# ---------------------------------------------------------
+print(f">>> [LOAD] Reading data from: {input_path}")
+try:
+    df = spark.read.csv(input_path, header=True, inferSchema=True)
+    df.printSchema()
+except Exception as e:
+    print(f">>> [ERROR] Could not read file. Error: {e}")
+    sys.exit(1)
+
+# ---------------------------------------------------------
+# 4. DYNAMIC COLUMN HANDLING
+# ---------------------------------------------------------
+print(">>> [PREP] Analyzing Column Types...")
+
+# --- CRITICAL UPDATE HERE ---
+# Added 'Header_Overhead_Ratio' to exclude it from the feature vector.
+# This ensures the dataset is informationally independent (removes redundancy with UDP_Ratio).
+excluded_cols = ['id', 'timestamp', 'date', '_c0', 'Serial_No', 'Header_Overhead_Ratio'] 
+
+# Separate remaining columns into Numerical vs Categorical (String)
+numeric_cols = []
+string_cols = []
+
+for field in df.schema.fields:
+    if field.name in excluded_cols:
+        continue
+    
+    # Check data type
+    dtype = str(field.dataType)
+    if "StringType" in dtype:
+        string_cols.append(field.name)
+    else:
+        # Integers, Doubles, Floats, Longs
+        numeric_cols.append(field.name)
+
+print(f">>> [INFO] Numeric Columns ({len(numeric_cols)}): {numeric_cols[:3]}...")
+print(f">>> [INFO] String Columns ({len(string_cols)}): {string_cols}")
+
+# ---------------------------------------------------------
+# 5. DEFINE PIPELINE STAGES
+# ---------------------------------------------------------
+stages = []
+
+# STAGE A: String Indexing (Convert Strings -> Numbers)
+indexed_string_cols = []
+for col_name in string_cols:
+    out_col = f"{col_name}_index"
+    indexer = StringIndexer(inputCol=col_name, outputCol=out_col, handleInvalid="keep")
+    stages.append(indexer)
+    indexed_string_cols.append(out_col)
+
+# STAGE B: Imputer (Handle Nulls in Numeric Data only)
+imputed_numeric_cols = [f"{c}_imputed" for c in numeric_cols]
+imputer = Imputer(
+    inputCols=numeric_cols, 
+    outputCols=imputed_numeric_cols
+).setStrategy("mean")
+stages.append(imputer)
+
+# STAGE C: Vector Assembler
+# Combine (Indexed Strings) + (Imputed Numerics) into one vector
+assembler_inputs = indexed_string_cols + imputed_numeric_cols
+assembler = VectorAssembler(
+    inputCols=assembler_inputs, 
+    outputCol="features_raw"
+)
+stages.append(assembler)
+
+# STAGE D: Standard Scaler
+scaler = StandardScaler(
+    inputCol="features_raw", 
+    outputCol="features_scaled",
+    withStd=True,
+    withMean=True
+)
+stages.append(scaler)
+
+# ---------------------------------------------------------
+# 6. EXECUTE PIPELINE
+# ---------------------------------------------------------
+print(">>> [EXEC] Fitting and Transforming Data...")
+pipeline = Pipeline(stages=stages)
+model = pipeline.fit(df)
+processed_df = model.transform(df)
+
+# ---------------------------------------------------------
+# 7. SAVE OUTPUT
+# ---------------------------------------------------------
+print(f">>> [SAVE] Writing processed data to: {output_path}")
+
+# Write output as Parquet (Compressed & Efficient)
+processed_df.select("features_scaled") \
+    .write \
+    .mode("overwrite") \
+    .parquet(output_path)
+
+print(">>> [DONE] Job Completed Successfully.")
+spark.stop()


### PR DESCRIPTION
@antonioroger2   Thanks for catching the mismatch. You were correct—while my report claimed Header_Overhead_Ratio was dropped to ensure informational independence, the code in kpi_preprocess.py was inadvertently including it in the feature vector.

The Fix: I have updated kpi_preprocess.py to explicitly add Header_Overhead_Ratio to the excluded_cols list.

Verification: I re-ran the full Spark pipeline on the cluster. The VectorAssembler now correctly skips this column, generating a final features_scaled vector of exactly 35 independent KPIs. This resolves the multicollinearity issue with UDP_Ratio and aligns the code with the documentation.

<img width="688" height="75" alt="image" src="https://github.com/user-attachments/assets/5f98e2d4-be54-4a65-ade7-6f04b83ab40c" />



I executed the following commands to patch the container and regenerate the dataset:
<img width="1031" height="116" alt="image" src="https://github.com/user-attachments/assets/38c4c9f6-e8f5-4fc5-8baf-95008aed358c" />

and output of these commands:
<img width="1029" height="460" alt="image" src="https://github.com/user-attachments/assets/0825b8d8-2899-4eff-81bd-c88664be4e09" />

<img width="472" height="716" alt="image" src="https://github.com/user-attachments/assets/1464a7b1-696e-41bd-a2f0-c14f36cc98da" />

<img width="1050" height="858" alt="image" src="https://github.com/user-attachments/assets/5982efca-fea1-4619-9daa-1b6254cf4f25" />


now we have proper final 35 IIF kpi_dataset 
